### PR TITLE
upgraded vault and added prometheusrules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # fury-kubernetes-vault
- Fury Kubernetes Vault deployment
+
+Fury Kubernetes Vault deployment
 
 ## Vault Packages
 
 Following packages are included in Fury Kubernetes Vault katalog:
 
-- [Vault](katalog/single): Vault is a tool for securely accessing
-secrets. A secret is anything that you want to tightly control
-access to, such as API keys, passwords, or certificates. Version: **1.2.2**
+-   [Vault](katalog/single): Vault is a tool for securely accessing
+    secrets. A secret is anything that you want to tightly control
+    access to, such as API keys, passwords, or certificates. Version: **1.7.2**
 
 Following packages are included in Fury Kubernetes Vault modules:
 
-- [aws/dynamo](modules/aws/dynamo): Creates an AWS DynamoDB table with an user
- with permissions to manage the table.
-- [aws/kms](modules/aws/kms): Creates KMS keys with an user with permissions to
- the key to encrypt and decrypt secrets.
-- [vault](modules/vault): Creates some [`vault_kubernetes_auth_backend_role`](https://www.terraform.io/docs/providers/vault/r/kubernetes_auth_backend_role.html) to be used in a Kubernetes cluster.
-
+-   [aws/dynamo](modules/aws/dynamo): Creates an AWS DynamoDB table with an user
+    with permissions to manage the table.
+-   [aws/kms](modules/aws/kms): Creates KMS keys with an user with permissions to
+    the key to encrypt and decrypt secrets.
+-   [vault](modules/vault): Creates some [`vault_kubernetes_auth_backend_role`](https://www.terraform.io/docs/providers/vault/r/kubernetes_auth_backend_role.html) to be used in a Kubernetes cluster.
 
 ## Compatibility
 
-| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             |
-|-------------------------------------|:------------------:|:------------------:|:------------------:|
-| v1.0.0                              |                    |                    |                    |
+| Module Version / Kubernetes Version | 1.14.X | 1.15.X | 1.16.X |
+| ----------------------------------- | :----: | :----: | :----: |
+| v1.0.0                              |        |        |        |
 
-- :white_check_mark: Compatible
-- :warning: Has issues
-- :x: Incompatible
+-   :white_check_mark: Compatible
+-   :warning: Has issues
+-   :x: Incompatible

--- a/katalog/single/deploy.yml
+++ b/katalog/single/deploy.yml
@@ -16,6 +16,7 @@ spec:
         app: vault
     spec:
       serviceAccount: vault
+      containers:
         - image: vault
           name: vault
           env:

--- a/katalog/single/kustomization.yaml
+++ b/katalog/single/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - sm.yml
   - rbac.yml
   - ns.yml
+  - pm.yml
 
 secretGenerator:
   - files:
@@ -15,9 +16,6 @@ secretGenerator:
     name: vault
 
 images:
-  - name: prom/statsd-exporter
-    newName: prom/statsd-exporter
-    newTag: v0.19.1
   - name: vault
     newName: vault
-    newTag: 1.6.2
+    newTag: 1.7.2

--- a/katalog/single/pm.yml
+++ b/katalog/single/pm.yml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: vault-alertrules
+spec:
+  groups:
+    - name: vault
+      rules:
+        - alert: VaultLeadershipLoss
+          expr: sum(increase(vault_core_leadership_lost_count{job="vault"}[1h])) > 5
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: High frequency of Vault leadership losses
+            description: There have been more than 5 Vault leadership losses in the past 1h
+
+        - alert: VaultLeadershipStepDowns
+          expr: sum(increase(vault_core_step_down_count{job="vault"}[1h])) > 5
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: High frequency of Vault leadership step downs
+            description: There have been more than 5 Vault leadership step downs in the past 1h
+
+        - alert: VaultLeadershipSetupFailures
+          expr: sum(increase(vault_core_leadership_setup_failed{job="vault"}[1h])) > 5
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: High frequency of Vault leadership setup failures
+            description: There have been more than 5 Vault leadership setup failures in the past 1h


### PR DESCRIPTION
Hi everyone 👋 !
Due to a sever bug : 
```Non-Expiring Leases: Vault and Vault Enterprise renewed nearly-expiring token
leases and dynamic secret leases with a zero-second TTL, causing them to be
treated as non-expiring, and never revoked. This issue affects Vault and Vault
Enterprise versions 0.10.0 through 1.7.1, and is fixed in 1.5.9, 1.6.5, and
1.7.2 (CVE-2021-32923).
```
Is pretty mandatory for this upgrade. I also added prometheusrules
