### PR TITLE
Fix Terraform providers version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,0 @@
-use asdf
-
-export AWS_ACCESS_KEY_ID=<your aws access key>
-export AWS_SECRET_ACCESS_KEY=<your aws secret access key>
-export AWS_DEFAULT_REGION=<your aws region>
-export VAULT_ADDR=<your vault address>
-export VAULT_TOKEN=<your vault token>

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-kustomize 3.8.6
-terraform 0.12.29

--- a/modules/aws/kms/main.tf
+++ b/modules/aws/kms/main.tf
@@ -1,9 +1,3 @@
-
-provider "aws" {
-  version = "~> 2.0"
-  region  = var.region
-}
-
 resource "aws_kms_key" "kms_k8s_vault" {
   description             = "KMS for Vault AutoSeal ${var.env}"
   deletion_window_in_days = 30

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = "0.15.4"
+  required_providers {
+    aws = "~> 3.0"
+  }
+}


### PR DESCRIPTION
The aim of this PR is the following:
- remove `.envrc` and `.tool-versions` files from this repository
- remove the `providers` block from the `aws/kms` Terraform module (providers inside modules are not a Terraform best practice)
- add Terraform and providers versions constraints (following current Terraform best practices)